### PR TITLE
Java 11 related library compatibility fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,12 +7,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [8, 11]
+    name: "Java ${{ matrix.java }} build"
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Java 11
+    - name: Set up Java
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: ${{ matrix.java }}
     - name: Cache Maven packages
       uses: actions/cache@v2
       with:

--- a/audit/forgerock-audit-benchmark/pom.xml
+++ b/audit/forgerock-audit-benchmark/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <!-- -DskipTests=false required to run benchmarks -->
         <skipTests>true</skipTests>
-        <jmh.version>1.21</jmh.version>
+        <jmh.version>1.27</jmh.version>
         <javac.target>1.8</javac.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/audit/pom.xml
+++ b/audit/pom.xml
@@ -39,7 +39,7 @@
         <supercsv.version>2.4.0</supercsv.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <javax.inject.version>1_3</javax.inject.version>
-        <hikaricp.version>3.2.0</hikaricp.version>
+        <hikaricp.version>4.0.1</hikaricp.version>
     </properties>
 
     <modules>

--- a/auth-filters/forgerock-authn-filter/forgerock-jaspi-functional-tests/pom.xml
+++ b/auth-filters/forgerock-authn-filter/forgerock-jaspi-functional-tests/pom.xml
@@ -125,7 +125,6 @@
         <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>forgerock-jaspi-runtime</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -157,7 +156,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.jayway.restassured</groupId>
+            <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
         </dependency>
 

--- a/auth-filters/forgerock-authz-filter-parent/authz-framework-functional-tests/pom.xml
+++ b/auth-filters/forgerock-authz-filter-parent/authz-framework-functional-tests/pom.xml
@@ -215,7 +215,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.jayway.restassured</groupId>
+            <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
         </dependency>
 

--- a/auth-filters/forgerock-authz-filter-parent/authz-framework-functional-tests/src/test/java/org/forgerock/authz/AuthzTestCase.java
+++ b/auth-filters/forgerock-authz-filter-parent/authz-framework-functional-tests/src/test/java/org/forgerock/authz/AuthzTestCase.java
@@ -18,10 +18,10 @@ package org.forgerock.authz;
 
 import org.testng.annotations.BeforeClass;
 
-import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.config.EncoderConfig;
-import com.jayway.restassured.config.RestAssuredConfig;
-import com.jayway.restassured.parsing.Parser;
+import io.restassured.RestAssured;
+import io.restassured.config.EncoderConfig;
+import io.restassured.config.RestAssuredConfig;
+import io.restassured.parsing.Parser;
 
 public class AuthzTestCase {
 

--- a/auth-filters/forgerock-authz-filter-parent/authz-framework-functional-tests/src/test/java/org/forgerock/authz/BasicCrestTestCases.java
+++ b/auth-filters/forgerock-authz-filter-parent/authz-framework-functional-tests/src/test/java/org/forgerock/authz/BasicCrestTestCases.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.authz;
 
-import static com.jayway.restassured.RestAssured.*;
+import static io.restassured.RestAssured.*;
 import static org.hamcrest.Matchers.*;
 
 import org.testng.annotations.Test;

--- a/auth-filters/forgerock-authz-filter-parent/authz-framework-functional-tests/src/test/java/org/forgerock/authz/modules/oauth2/crest/OAuth2CrestAuthorizationModuleTestCases.java
+++ b/auth-filters/forgerock-authz-filter-parent/authz-framework-functional-tests/src/test/java/org/forgerock/authz/modules/oauth2/crest/OAuth2CrestAuthorizationModuleTestCases.java
@@ -16,7 +16,7 @@
 
 package org.forgerock.authz.modules.oauth2.crest;
 
-import static com.jayway.restassured.RestAssured.*;
+import static io.restassured.RestAssured.*;
 import static org.hamcrest.Matchers.*;
 
 import org.forgerock.authz.AuthzTestCase;

--- a/auth-filters/pom.xml
+++ b/auth-filters/pom.xml
@@ -112,13 +112,13 @@
             <dependency>
                 <groupId>org.glassfish</groupId>
                 <artifactId>javax.security.auth.message</artifactId>
-                <version>3.1</version>
+                <version>3.1.1</version>
             </dependency>
 
             <dependency>
-                <groupId>com.jayway.restassured</groupId>
+                <groupId>io.rest-assured</groupId>
                 <artifactId>rest-assured</artifactId>
-                <version>2.3.0</version>
+                <version>4.3.3</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/commons-bom/pom.xml
+++ b/commons-bom/pom.xml
@@ -37,17 +37,18 @@
     <url>https://www.wrensecurity.org</url>
 
     <properties>
-        <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.5.1</pgpWhitelistArtifact>
+        <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.5.2-SNAPSHOT</pgpWhitelistArtifact>
 
         <!-- Third party components versions -->
         <i18nFrameworkVersion>1.4.3</i18nFrameworkVersion>
         <jodaTime.version>2.10.9</jodaTime.version>
         <assertj.version>3.19.0</assertj.version>
         <forgerock-guava.version>18.0.4</forgerock-guava.version>
+        <jaxb-osgi.version>2.3.3</jaxb-osgi.version>
+        <activation.version>2.0.0</activation.version>
         <jackson.version>2.12.1</jackson.version>
-        <jaxb.version>2.3.1</jaxb.version>
         <mockito.version>3.7.7</mockito.version>
-        <servlet-api.version>4.0.1</servlet-api.version>
+        <servlet-api.version>3.1.0</servlet-api.version>
         <slf4j.version>1.7.30</slf4j.version>
         <testng.version>7.3.0</testng.version>
         <swagger.version>1.6.2</swagger.version>
@@ -147,6 +148,20 @@
                 <version>${slf4j.version}</version>
             </dependency>
 
+            <!-- Override version managed by testng to version required by swagger -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>27.0.1-android</version>
+            </dependency>
+
+            <!-- Override version managed by testng to version required by jackson-dataformat-yaml -->
+            <dependency>
+              <groupId>org.yaml</groupId>
+              <artifactId>snakeyaml</artifactId>
+              <version>1.27</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
@@ -242,9 +257,21 @@
             </dependency>
 
             <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
-                <version>${jaxb.version}</version>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-osgi</artifactId>
+                <version>${jaxb-osgi.version}</version>
+                <exclusions>
+                    <exclusion>
+                      <groupId>com.sun.activation</groupId>
+                      <artifactId>jakarta.activation</artifactId>
+                    </exclusion>
+              </exclusions>
+            </dependency>
+
+            <dependency>
+              <groupId>jakarta.activation</groupId>
+              <artifactId>jakarta.activation-api</artifactId>
+              <version>${activation.version}</version>
             </dependency>
 
             <dependency>

--- a/http-framework/http-benchmarks/pom.xml
+++ b/http-framework/http-benchmarks/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>forgerock-http-framework-parent</artifactId>
     <groupId>org.forgerock.http</groupId>
-    <version>22.0.0-SNAPSHOT</version>
+    <version>22.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>chf-benchmarks</artifactId>

--- a/http-framework/http-core/pom.xml
+++ b/http-framework/http-core/pom.xml
@@ -90,7 +90,6 @@
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-jsr223</artifactId>
-      <version>2.3.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/http-framework/http-servlet/pom.xml
+++ b/http-framework/http-servlet/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.forgerock.commons</groupId>
       <artifactId>forgerock-guice-core</artifactId>
-      <version>1.1.0</version>
+      <version>2.0.0</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>

--- a/http-framework/pom.xml
+++ b/http-framework/pom.xml
@@ -45,6 +45,7 @@
     <module>http-client-apache-async</module>
     <module>http-examples</module>
     <module>binding-test-utils</module>
+    <module>http-benchmarks</module>
     <module>http-oauth2</module>
     <module>http-client-test-utils</module>
   </modules>
@@ -78,10 +79,17 @@
 
   <dependencyManagement>
     <dependencies>
+
+      <dependency>
+        <groupId>org.codehaus.groovy</groupId>
+        <artifactId>groovy-jsr223</artifactId>
+        <version>3.0.7</version>
+      </dependency>
+
       <dependency>
         <groupId>com.xebialabs.restito</groupId>
         <artifactId>restito</artifactId>
-        <version>0.8.2</version>
+        <version>0.9.4</version>
       </dependency>
 
       <dependency>

--- a/json-crypto/pom.xml
+++ b/json-crypto/pom.xml
@@ -55,8 +55,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-osgi</artifactId>
         </dependency>
 
     </dependencies>

--- a/json-schema/json-schema-core/pom.xml
+++ b/json-schema/json-schema-core/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>
             <artifactId>json-simple</artifactId>
-            <version>1.1</version>
+            <version>1.1.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/json-web-token/pom.xml
+++ b/json-web-token/pom.xml
@@ -61,11 +61,6 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>
@@ -73,6 +68,11 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-osgi</artifactId>
         </dependency>
 
         <dependency>

--- a/rest/api-descriptor/pom.xml
+++ b/rest/api-descriptor/pom.xml
@@ -22,6 +22,7 @@
         <groupId>org.forgerock.commons</groupId>
         <artifactId>forgerock-rest</artifactId>
         <version>22.1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>api-descriptor</artifactId>
@@ -35,7 +36,7 @@
     </description>
 
     <properties>
-        <rhino.version>1.7.10</rhino.version>
+        <rhino.version>1.7.13</rhino.version>
     </properties>
 
     <build>
@@ -113,7 +114,7 @@
         <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>javax.mail-api</artifactId>
-            <version>1.5.5</version>
+            <version>1.6.2</version>
             <scope>provided</scope>
         </dependency>
 

--- a/rest/json-resource/pom.xml
+++ b/rest/json-resource/pom.xml
@@ -52,6 +52,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.servicemix.specs</groupId>
+            <artifactId>org.apache.servicemix.specs.activation-api-1.1</artifactId>
+            <version>2.9.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>forgerock-test-utils</artifactId>
             <scope>test</scope>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -22,6 +22,7 @@
         <groupId>org.forgerock.commons</groupId>
         <artifactId>commons-parent</artifactId>
         <version>22.1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>forgerock-rest</artifactId>
@@ -48,9 +49,8 @@
     <dependencies>
 
         <dependency>
-             <groupId>javax.xml.bind</groupId>
-             <artifactId>jaxb-api</artifactId>
-             <version>${jaxb.version}</version>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-osgi</artifactId>
         </dependency>
 
         <dependency>
@@ -77,8 +77,9 @@
             <dependency>
                 <groupId>com.sun.mail</groupId>
                 <artifactId>javax.mail</artifactId>
-                <version>1.5.1</version>
+                <version>1.6.2</version>
             </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/self-service/forgerock-selfservice-core/pom.xml
+++ b/self-service/forgerock-selfservice-core/pom.xml
@@ -22,6 +22,7 @@
         <artifactId>forgerock-selfservice</artifactId>
         <groupId>org.forgerock.commons</groupId>
         <version>22.1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>forgerock-selfservice-core</artifactId>
@@ -36,6 +37,11 @@
         <dependency>
             <groupId>org.forgerock.commons</groupId>
             <artifactId>json-resource</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-osgi</artifactId>
         </dependency>
 
         <dependency>

--- a/util/forgerock-util/pom.xml
+++ b/util/forgerock-util/pom.xml
@@ -21,6 +21,7 @@
         <groupId>org.forgerock.commons</groupId>
         <artifactId>forgerock-utilities</artifactId>
         <version>22.1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>forgerock-util</artifactId>
@@ -84,6 +85,11 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>!org.apache.xerces.util,*</Import-Package>
+                    </instructions>
+                </configuration>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
This pull request addresses issues created by updating some of the commons' dependencies.
The main changes are

- rename `com.jayway.restassured` to `io.rest-assured`
- revert servlet-api update to 3.1.0
- override versions of snakeyaml and guava managed by testng causing clash with demands of swagger
- replace jaxb servicemix with jaxb-osgi and jakarta.xml.bind
- prevent (previously hidden and silently ignored by bundle plugin) Xerces dependency from creeping into the utils' manifest
- few minor cosmetic fixes like adding relativepath to parent pom and removing unnecessary version specifiers when the version is already managed