### PR TITLE
Fix JsonFileWriter to not block on shutdown when not started.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto
+
+# Use LF line endings where required by unit tests
+*.txt eol=lf
+*.json eol=lf
+*.properties eol=lf
+*.conf eol=lf
+

--- a/rest/json-resource-http/src/test/java/org/forgerock/json/resource/http/HttpAdapterTest.java
+++ b/rest/json-resource-http/src/test/java/org/forgerock/json/resource/http/HttpAdapterTest.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions Copyright 2018 Wren Security.
+ * Portions Copyright 2018-2021 Wren Security.
  */
 package org.forgerock.json.resource.http;
 
@@ -152,7 +152,8 @@ public class HttpAdapterTest {
         assertThatPromise(result).succeeded();
         Entity entity = result.get().getEntity();
         assertThat(JsonValue.json(entity.getJson())).isObject().stringAt("id").isEqualTo("test:descriptor");
-        assertThat(entity.getString()).startsWith("{\n  \"id\" : \"test:descriptor\",\n  \"version\" : \"1.0\",\n");
+        assertThat(entity.getString().replaceAll("\r", ""))
+                .startsWith("{\n  \"id\" : \"test:descriptor\",\n  \"version\" : \"1.0\",\n");
     }
 
     @Test


### PR DESCRIPTION
This changes `JsonFileWriter` to make sure that the scheduler is actually shutdown on `shutdown()` request. The original implementation relied on the scheduled task (`QueueConsumer`) to shut down it's own executor service. However that is not that reliable - when the audit handler framework is incorrectly used then `start()` might not have been called and the `QueueConsumer` is hence never scheduled.

I came across this issue in Wren:AM - there is probably a second part for this issue (calling `stop` on non-started audit service), but I wanted to fix it here as well as I guess this component should not block the main thread in any case.
