### PR TITLE
Add support for returning Kerberos realm

### DIFF
--- a/auth-filters/forgerock-authn-filter/forgerock-jaspi-modules/forgerock-jaspi-iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/wdsso/WDSSO.java
+++ b/auth-filters/forgerock-authn-filter/forgerock-jaspi-modules/forgerock-jaspi-iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/wdsso/WDSSO.java
@@ -224,6 +224,7 @@ public class WDSSO {
         keyTabFile = null;
         kdcRealm = null;
         kdcServer = null;
+        returnRealm = false;
     }
 
     private String getUserName(String user) {
@@ -340,8 +341,11 @@ public class WDSSO {
         keyTabFile = options.get("keytabFileName");
         kdcRealm = options.get("kerberosRealm");
         kdcServer = options.get("kerberosServerName");
-        LOG.debug("IWA WDSSO: WindowsDesktopSSO params: principal: {}, keytab file: {}, realm : {}, kdc server: {}",
-                servicePrincipalName, keyTabFile, kdcRealm, kdcServer);
+        if (options.get("returnRealm") != null) {
+            returnRealm = Boolean.valueOf(options.get("returnRealm"));
+        }
+        LOG.debug("IWA WDSSO: WindowsDesktopSSO params: principal: {}, keytab file: {}, realm : {}, kdc server: {}, returnRealm: {}",
+                servicePrincipalName, keyTabFile, kdcRealm, kdcServer, returnRealm);
         return serviceSubject != null;
     }
 


### PR DESCRIPTION
This PR adds configuration option for `returnRealm` flag, so you are able to return principal with his realm.