### PR TITLE
Get rid of type arguments

### DIFF
--- a/http-framework/http-core/src/main/java/org/forgerock/http/io/PipeBufferedStream.java
+++ b/http-framework/http-core/src/main/java/org/forgerock/http/io/PipeBufferedStream.java
@@ -41,14 +41,14 @@ public final class PipeBufferedStream {
     private int position = 0;
 
     /**
-     * Constructs a new {@link PipeBufferedStream} with a default {@link Factory<Buffer>}.
+     * Constructs a new {@link PipeBufferedStream} with a default {@link Factory}.
      */
     public PipeBufferedStream() {
         this(IO.newTemporaryStorage());
     }
 
     /**
-     * Constructs a new {@link PipeBufferedStream} with the given {@link Factory<Buffer>}.
+     * Constructs a new {@link PipeBufferedStream} with the given {@link Factory}.
      *
      * @param bufferFactory The buffer factory to use to create the {@link BranchingInputStream}
      */


### PR DESCRIPTION
Fixes error produced by generation of javadoc report on `mvn site` execution.