### PR TITLE
Exclude unused transient Guava dependencies

### DIFF
--- a/commons-bom/pom.xml
+++ b/commons-bom/pom.xml
@@ -156,6 +156,32 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>27.0.1-android</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>listenablefuture</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.j2objc</groupId>
+                        <artifactId>j2objc-annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.checkerframework</groupId>
+                        <artifactId>checker-compat-qual</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>animal-sniffer-annotations</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- Override version managed by testng to version required by jackson-dataformat-yaml -->


### PR DESCRIPTION
Guava brings some dependencies to the build that are required only compile-time (https://www.github.com/google/guava/issues/2824)

This commit excludes following dependencies:

* `com.google.code.findbugs:jsr305`
* `com.google.errorprone:error_prone_annotations`
* `com.google.guava:listenablefuture`
* `com.google.j2objc:j2objc-annotations`
* `org.checkerframework:checker-compat-qual`
* `org.codehaus.mojo:animal-sniffer-annotations`