### PR TITLE
Fix build of Javadoc and site build

### DIFF
--- a/guice/guice-core/src/main/java/org/forgerock/guice/core/internal/commons/lang/reflect/ConstructorUtils.java
+++ b/guice/guice-core/src/main/java/org/forgerock/guice/core/internal/commons/lang/reflect/ConstructorUtils.java
@@ -30,8 +30,8 @@ import java.lang.reflect.Modifier;
 /**
  * Utility reflection methods focussed on constructors, modelled after {@link MemberUtils}.
  *
- * <h3>Known Limitations</h3>
- * <h4>Accessing Public Constructors In A Default Access Superclass</h4>
+ * <h2>Known Limitations</h2>
+ * <h3>Accessing Public Constructors In A Default Access Superclass</h3>
  * <p>There is an issue when invoking public constructors contained in a default access superclass.
  * Reflection locates these constructors fine and correctly assigns them as public.
  * However, an <code>IllegalAccessException</code> is thrown if the constructors is invoked.</p>

--- a/i18n/i18n-core/src/main/javadoc/overview.html
+++ b/i18n/i18n-core/src/main/javadoc/overview.html
@@ -40,28 +40,28 @@
     Once you have your property files defined you can use the
     <b>i18n-maven-plugin</b> to generate the messages. To do this, add the
     following lines to your pom.xml:
-    <pre>  &lt;build>
-    &lt;plugins>
-      &lt;plugin>
-        &lt;groupId>org.wrensecurity.commons&lt;/groupId>
-        &lt;artifactId>i18n-maven-plugin&lt;/artifactId>
-        &lt;version>${project.version}&lt;/version>
-        &lt;executions>
-          &lt;execution>
-            &lt;phase>generate-sources&lt;/phase>
-            &lt;goals>
-              &lt;goal>generate-messages&lt;/goal>
-            &lt;/goals>
-            &lt;configuration>
-              &lt;messageFiles>
-                &lt;messageFile>com/example/myapp/core.properties&lt;/messageFile>
-              &lt;/messageFiles>
-            &lt;/configuration>
-          &lt;/execution>
-        &lt;/executions>
-      &lt;/plugin>
-    &lt;/plugins>
-  &lt;/build>
+    <pre>  &lt;build&gt;
+    &lt;plugins&gt;
+      &lt;plugin&gt;
+        &lt;groupId&gt;org.wrensecurity.commons&lt;/groupId&gt;
+        &lt;artifactId&gt;i18n-maven-plugin&lt;/artifactId&gt;
+        &lt;version&gt;${project.version}&lt;/version&gt;
+        &lt;executions&gt;
+          &lt;execution&gt;
+            &lt;phase&gt;generate-sources&lt;/phase&gt;
+            &lt;goals&gt;
+              &lt;goal&gt;generate-messages&lt;/goal&gt;
+            &lt;/goals&gt;
+            &lt;configuration&gt;
+              &lt;messageFiles&gt;
+                &lt;messageFile&gt;com/example/myapp/core.properties&lt;/messageFile&gt;
+              &lt;/messageFiles&gt;
+            &lt;/configuration&gt;
+          &lt;/execution&gt;
+        &lt;/executions&gt;
+      &lt;/plugin&gt;
+    &lt;/plugins&gt;
+  &lt;/build&gt;
     </pre>
     This will generate a Java file in
     <b>target/generated-sources/messages/com/example/myapp/CoreMessages.java</b>
@@ -79,23 +79,23 @@
     /**
     * Arg1=%s
     */
-    public static final LocalizableMessageDescriptor.Arg1&lt;CharSequence> MESSAGE_WITH_STRING =
-            new LocalizableMessageDescriptor.Arg1&lt;CharSequence>(CoreMessages.class,RESOURCE,"MESSAGE_WITH_STRING",-1);
+    public static final LocalizableMessageDescriptor.Arg1&lt;CharSequence&gt; MESSAGE_WITH_STRING =
+            new LocalizableMessageDescriptor.Arg1&lt;CharSequence&gt;(CoreMessages.class,RESOURCE,"MESSAGE_WITH_STRING",-1);
 
     /**
     * Arg1=%s Arg2=%d
     */
-    public static final LocalizableMessageDescriptor.Arg2&lt;CharSequence,Number> MESSAGE_WITH_STRING_AND_NUMBER =
-            new LocalizableMessageDescriptor.Arg2&lt;CharSequence,Number>(CoreMessages.class,RESOURCE,"MESSAGE_WITH_STRING_AND_NUMBER",-1);
+    public static final LocalizableMessageDescriptor.Arg2&lt;CharSequence,Number&gt; MESSAGE_WITH_STRING_AND_NUMBER =
+            new LocalizableMessageDescriptor.Arg2&lt;CharSequence,Number&gt;(CoreMessages.class,RESOURCE,"MESSAGE_WITH_STRING_AND_NUMBER",-1);
 
   }
     </pre>
     To use the generated messages you'll need the following dependency:
     <pre>
-  &lt;groupId>org.wrensecurity.commons&lt;/groupId>
-  &lt;artifactId>i18n-core&lt;/artifactId>
-  &lt;version>${project.version}&lt;/version>
-  &lt;scope>compile&lt;/scope>
+  &lt;groupId&gt;org.wrensecurity.commons&lt;/groupId&gt;
+  &lt;artifactId&gt;i18n-core&lt;/artifactId&gt;
+  &lt;version&gt;${project.version}&lt;/version&gt;
+  &lt;scope&gt;compile&lt;/scope&gt;
     </pre>
     Messages can then be instantiated in a type safe manner which is enforced at
     compile time (unlike CAL10N) as well as avoiding runtime errors due to

--- a/i18n/i18n-maven-plugin/pom.xml
+++ b/i18n/i18n-maven-plugin/pom.xml
@@ -39,58 +39,15 @@
             <version>3.8.6</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.6.4</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>3.8.6</version>
         </dependency>
     </dependencies>
-
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-plugin-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <tags>
-                        <tag>
-                            <name>Checkstyle\\:ignoreFor</name>
-                            <placement>X</placement>
-                        </tag>
-                        <tag>
-                            <name>Checkstyle\\:ignore</name>
-                            <placement>X</placement>
-                        </tag>
-                        <tag>
-                            <name>goal</name>
-                            <placement>X</placement>
-                        </tag>
-                        <tag>
-                            <name>parameter</name>
-                            <placement>X</placement>
-                        </tag>
-                        <tag>
-                            <name>phase</name>
-                            <placement>X</placement>
-                        </tag>
-                        <tag>
-                            <name>readonly</name>
-                            <placement>X</placement>
-                        </tag>
-                        <tag>
-                            <name>required</name>
-                            <placement>X</placement>
-                        </tag>
-                        <tag>
-                            <name>threadSafe</name>
-                            <placement>X</placement>
-                        </tag>
-                    </tags>
-                </configuration>
-            </plugin>
-        </plugins>
-    </reporting>
 </project>

--- a/i18n/i18n-maven-plugin/src/main/java/org/forgerock/i18n/maven/AbstractGenerateMessagesMojo.java
+++ b/i18n/i18n-maven-plugin/src/main/java/org/forgerock/i18n/maven/AbstractGenerateMessagesMojo.java
@@ -37,6 +37,7 @@ import java.util.regex.Pattern;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
 /**
@@ -489,28 +490,21 @@ abstract class AbstractGenerateMessagesMojo extends AbstractMojo {
     /**
      * Indicates whether or not message files should be regenerated even if they
      * are already up to date.
-     *
-     * @parameter default-value="false"
-     * @required
      */
+    @Parameter(defaultValue="false", required=true)
     private boolean force;
 
     /**
      * The list of files we want to transfer, relative to the resource
      * directory.
-     *
-     * @parameter
-     * @required
      */
+    @Parameter(required=true)
     private String[] messageFiles;
 
     /**
      * The current Maven project.
-     *
-     * @parameter default-value="${project}"
-     * @readonly
-     * @required
      */
+    @Parameter(defaultValue="${project}", readonly=true, required=true)
     private MavenProject project;
 
     /**

--- a/i18n/i18n-maven-plugin/src/main/java/org/forgerock/i18n/maven/CleanMessagesMojo.java
+++ b/i18n/i18n-maven-plugin/src/main/java/org/forgerock/i18n/maven/CleanMessagesMojo.java
@@ -11,7 +11,8 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
- *      Copyright 2011 ForgeRock AS
+ * Copyright 2011 ForgeRock AS
+ * Portions Copyright 2022 Wren Security.
  */
 package org.forgerock.i18n.maven;
 
@@ -36,14 +37,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Goal which cleans unused messages files from a property file.
- *
- * @Checkstyle:ignore
- * @goal clean-messages
- * @threadSafe
  */
+@Mojo(name="clean-messages", threadSafe=true)
 @SuppressWarnings("resource")
 public final class CleanMessagesMojo extends AbstractMojo {
 
@@ -106,26 +106,20 @@ public final class CleanMessagesMojo extends AbstractMojo {
 
     /**
      * The target directory in which the source files should be generated.
-     *
-     * @parameter default-value="${project.build.sourceDirectory}"
-     * @required
      */
+    @Parameter(defaultValue="${project.build.sourceDirectory}", required=true)
     private File sourceDirectory;
 
     /**
      * The message message file to be cleaned.
-     *
-     * @parameter
-     * @required
      */
+    @Parameter(required=true)
     private File messageFile;
 
     /**
      * The encoding argument used by Java source files.
-     *
-     * @parameter default-value="${project.build.sourceEncoding}"
-     * @required
      */
+    @Parameter(defaultValue="${project.build.sourceEncoding}", required=true)
     private String encoding;
 
     private final Map<MessagePropertyKey, String> unreferencedProperties =

--- a/i18n/i18n-maven-plugin/src/main/java/org/forgerock/i18n/maven/GenerateMessagesMojo.java
+++ b/i18n/i18n-maven-plugin/src/main/java/org/forgerock/i18n/maven/GenerateMessagesMojo.java
@@ -11,37 +11,33 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
- *      Copyright 2011 ForgeRock AS
+ * Copyright 2011 ForgeRock AS
+ * Portions Copyright 2022 Wren Security.
  */
 package org.forgerock.i18n.maven;
 
 import java.io.File;
 
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
 /**
  * Goal which generates message source files from a one or more property files.
- *
- * @Checkstyle:ignoreFor 2
- * @goal generate-messages
- * @phase generate-sources
- * @threadSafe
  */
+@Mojo(name="generate-messages", defaultPhase=LifecyclePhase.GENERATE_SOURCES, threadSafe=true)
 public final class GenerateMessagesMojo extends AbstractGenerateMessagesMojo {
 
     /**
      * The target directory in which the source files should be generated.
-     *
-     * @parameter
-     *            default-value="${project.build.directory}/generated-sources/messages"
-     * @required
      */
+    @Parameter(defaultValue="${project.build.directory}/generated-sources/messages", required=true)
     private File targetDirectory;
 
     /**
      * The resource directory containing the message files.
-     *
-     * @parameter default-value="${basedir}/src/main/resources"
-     * @required
      */
+    @Parameter(defaultValue="${basedir}/src/main/resources", required=true)
     private File resourceDirectory;
 
     /**

--- a/i18n/i18n-maven-plugin/src/main/java/org/forgerock/i18n/maven/GenerateTestMessagesMojo.java
+++ b/i18n/i18n-maven-plugin/src/main/java/org/forgerock/i18n/maven/GenerateTestMessagesMojo.java
@@ -11,38 +11,34 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
- *      Copyright 2011 ForgeRock AS
+ * Copyright 2011 ForgeRock AS
+ * Portions Copyright 2022 Wren Security.
  */
 package org.forgerock.i18n.maven;
 
 import java.io.File;
 
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
 /**
  * Goal which generates message source files from a one or more property files.
- *
- * @Checkstyle:ignoreFor 2
- * @goal generate-test-messages
- * @phase generate-test-sources
- * @threadSafe
  */
+@Mojo(name="generate-test-messages", defaultPhase=LifecyclePhase.GENERATE_TEST_SOURCES, threadSafe=true)
 public final class GenerateTestMessagesMojo extends
         AbstractGenerateMessagesMojo {
 
     /**
      * The target directory in which the source files should be generated.
-     *
-     * @parameter default-value=
-     *            "${project.build.directory}/generated-test-sources/messages"
-     * @required
      */
+    @Parameter(defaultValue="${project.build.directory}/generated-test-sources/messages", required=true)
     private File targetDirectory;
 
     /**
      * The resource directory containing the message files.
-     *
-     * @parameter default-value="${basedir}/src/test/resources"
-     * @required
      */
+    @Parameter(defaultValue="${basedir}/src/test/resources", required=true)
     private File resourceDirectory;
 
     /**


### PR DESCRIPTION
The following changes have been performed to fix build of Javadoc and site:

* Use annotations for `maven-plugin-plugin`.
  * Remove useless `maven-javadoc-plugin` configuration.
* Fix JavaDoc overview for `i18n-core` module.
* Fix invalid header hierarchy `ConstructorUtils`.