### PR TITLE
Upgrade project structure and parent

### DIFF
--- a/audit/pom.xml
+++ b/audit/pom.xml
@@ -35,7 +35,6 @@
 
     <properties>
         <supercsv.version>2.4.0</supercsv.version>
-        <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <javax.inject.version>1_3</javax.inject.version>
         <hikaricp.version>4.0.1</hikaricp.version>
     </properties>
@@ -79,7 +78,6 @@
             <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
-                <version>${javax.servlet-api.version}</version>
                 <scope>provided</scope>
             </dependency>
         </dependencies>

--- a/auth-filters/forgerock-authn-filter/forgerock-jaspi-modules/forgerock-jaspi-jwt-session-module/pom.xml
+++ b/auth-filters/forgerock-authn-filter/forgerock-jaspi-modules/forgerock-jaspi-jwt-session-module/pom.xml
@@ -68,7 +68,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>${servlet-api.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/commons-bom/pom.xml
+++ b/commons-bom/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wrensecurity</groupId>
         <artifactId>wrensec-parent</artifactId>
-        <version>3.3.0</version>
+        <version>3.5.0</version>
         <relativePath />
     </parent>
 
@@ -34,15 +34,9 @@
     <description>
         Provides a list of common dependencies which are known to be compatible with each other.
     </description>
-    <url>https://www.wrensecurity.org</url>
+    <url>https://wrensecurity.org</url>
 
     <properties>
-        <pgpWhitelistArtifact>org.wrensecurity:wrensec-pgp-whitelist:1.5.6</pgpWhitelistArtifact>
-
-        <!-- Parent plugin version overrides -->
-        <mavenReleasePluginVersion>3.0.0-M6</mavenReleasePluginVersion>
-
-        <!-- Third party components versions -->
         <jodaTime.version>2.10.9</jodaTime.version>
         <assertj.version>3.19.0</assertj.version>
         <wrensec-guava.version>18.0.5</wrensec-guava.version>
@@ -54,56 +48,8 @@
         <slf4j.version>1.7.30</slf4j.version>
         <testng.version>7.3.0</testng.version>
         <swagger.version>1.6.2</swagger.version>
-        <apache-httpcore.version>4.4.14</apache-httpcore.version>
-        <apache-httpclient.version>4.5.13</apache-httpclient.version>
-        <apache-httpasyncclient.version>4.1.4</apache-httpasyncclient.version>
         <jsr305.version>3.0.2</jsr305.version>
     </properties>
-
-    <repositories>
-        <!-- Needed to retrieve parent POM -->
-        <repository>
-            <id>wrensecurity-releases</id>
-            <name>Wren Security Release Repository</name>
-            <url>https://wrensecurity.jfrog.io/wrensecurity/releases</url>
-
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-        </repository>
-
-        <!-- Needed to retrieve parent POM -->
-        <repository>
-            <id>wrensecurity-snapshots</id>
-            <name>Wren Security Snapshot Repository</name>
-            <url>https://wrensecurity.jfrog.io/wrensecurity/snapshots</url>
-
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository>
-    </repositories>
-
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <!-- TODO: Move into `wrensec-parent` -->
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>clirr-maven-plugin</artifactId>
-                    <version>${clirrPluginVersion}</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
 
     <dependencyManagement>
         <dependencies>

--- a/http-framework/http-client-apache-async/pom.xml
+++ b/http-framework/http-client-apache-async/pom.xml
@@ -27,6 +27,10 @@
   <artifactId>chf-client-apache-async</artifactId>
   <name>Wren Security Commons HTTP - Apache Async HttpClient integration</name>
 
+  <properties>
+    <apache-httpasyncclient.version>4.1.4</apache-httpasyncclient.version>
+  </properties>
+
   <build>
     <plugins>
       <plugin>

--- a/http-framework/http-client-apache-common/pom.xml
+++ b/http-framework/http-client-apache-common/pom.xml
@@ -27,6 +27,11 @@
   <artifactId>chf-client-apache-common</artifactId>
   <name>Wren Security Commons HTTP - Apache HttpClient(s) base</name>
 
+  <properties>
+    <apache-httpclient.version>4.5.13</apache-httpclient.version>
+    <apache-httpcore.version>4.4.14</apache-httpcore.version>
+  </properties>
+
   <build>
     <plugins>
       <plugin>

--- a/http-framework/http-examples/http-descriptor-example/pom.xml
+++ b/http-framework/http-examples/http-descriptor-example/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>

--- a/http-framework/http-examples/http-servlet-example/pom.xml
+++ b/http-framework/http-examples/http-servlet-example/pom.xml
@@ -46,7 +46,6 @@
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>${servlet-api.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,72 +16,131 @@
    Portions Copyright 2017-2018 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-     <groupId>org.wrensecurity.commons</groupId>
-     <artifactId>commons-bom</artifactId>
-     <relativePath>commons-bom/pom.xml</relativePath>
-     <version>22.4.0-SNAPSHOT</version>
-  </parent>
+    <parent>
+        <groupId>org.wrensecurity</groupId>
+        <artifactId>wrensec-parent</artifactId>
+        <version>3.5.0</version>
+        <relativePath />
+    </parent>
 
-  <artifactId>commons-parent</artifactId>
-  <packaging>pom</packaging>
+    <groupId>org.wrensecurity.commons</groupId>
+    <artifactId>commons-parent</artifactId>
+    <version>22.4.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
 
-  <name>Wren Security Commons - Parent</name>
-  <description>
-    This group modules includes the Wren Security common components.
-  </description>
-  <url>https://github.com/WrenSecurity/wrensec-commons</url>
-
-  <licenses>
-    <license>
-      <name>CDDL-1.0</name>
-      <url>http://opensource.org/licenses/CDDL-1.0</url>
-      <comments>Common Development and Distribution License (CDDL) 1.0</comments>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
-
-  <issueManagement>
-    <system>GitHub Issues</system>
-    <url>https://github.com/WrenSecurity/wrensec-commons/issues</url>
-  </issueManagement>
-
-  <scm>
+    <name>Wren Security Commons - Parent</name>
+    <description>
+        This group modules includes the Wren Security common components.
+    </description>
     <url>https://github.com/WrenSecurity/wrensec-commons</url>
-    <connection>scm:git:git://github.com/WrenSecurity/wrensec-commons.git</connection>
-    <developerConnection>scm:git:git@github.com:WrenSecurity/wrensec-commons.git</developerConnection>
-    <tag>HEAD</tag>
-  </scm>
 
-  <modules>
-    <module>commons-bom</module>
-    <module>audit</module>
-    <module>auth-filters</module>
-    <module>guice</module>
-    <module>http-framework</module>
-    <module>i18n</module>
-    <module>json-crypto</module>
-    <module>json-ref</module>
-    <module>json-schema</module>
-    <module>json-web-token</module>
-    <module>rest</module>
-    <module>self-service</module>
-    <module>util</module>
-    <module>security</module>
-  </modules>
+    <licenses>
+        <license>
+            <name>CDDL-1.0</name>
+            <url>http://opensource.org/licenses/CDDL-1.0</url>
+            <comments>Common Development and Distribution License (CDDL) 1.0</comments>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
+    <issueManagement>
+        <system>GitHub Issues</system>
+        <url>https://github.com/WrenSecurity/wrensec-commons/issues</url>
+    </issueManagement>
 
-        <configuration>
-          <additionalparam>-Xdoclint:none</additionalparam>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+    <scm>
+        <url>https://github.com/WrenSecurity/wrensec-commons</url>
+        <connection>scm:git:git://github.com/WrenSecurity/wrensec-commons.git</connection>
+        <developerConnection>scm:git:git@github.com:WrenSecurity/wrensec-commons.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <repositories>
+        <repository>
+            <id>wrensecurity-releases</id>
+            <name>Wren Security Release Repository</name>
+            <url>https://wrensecurity.jfrog.io/wrensecurity/releases</url>
+
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+
+        <repository>
+            <id>wrensecurity-snapshots</id>
+            <name>Wren Security Snapshot Repository</name>
+            <url>https://wrensecurity.jfrog.io/wrensecurity/snapshots</url>
+
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+    </repositories>
+
+    <properties>
+        <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>commons-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <modules>
+        <module>commons-bom</module>
+        <module>audit</module>
+        <module>auth-filters</module>
+        <module>guice</module>
+        <module>http-framework</module>
+        <module>i18n</module>
+        <module>json-crypto</module>
+        <module>json-ref</module>
+        <module>json-schema</module>
+        <module>json-web-token</module>
+        <module>rest</module>
+        <module>self-service</module>
+        <module>util</module>
+        <module>security</module>
+    </modules>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <!-- TODO: Move into `wrensec-parent` -->
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>clirr-maven-plugin</artifactId>
+                    <version>${clirrPluginVersion}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+
+                <configuration>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/rest/json-resource-http/pom.xml
+++ b/rest/json-resource-http/pom.xml
@@ -104,7 +104,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>${servlet-api.version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
I have upgraded to the latest parent and upgraded project hierarchy (BOM is now BOM and not a parent POM).

I have intentionally moved few properties from commons-bom to projects where the dependencies are defined. More correct solution would be to move those dependency definitions to BOM, but such change is for another day.
