### PR TITLE
Add doc-common-content empty package.

### DIFF
--- a/doc-maven/doc-common-content/pom.xml
+++ b/doc-maven/doc-common-content/pom.xml
@@ -19,22 +19,9 @@
 
     <parent>
         <groupId>org.wrensecurity.commons</groupId>
-        <artifactId>commons-parent</artifactId>
+        <artifactId>doc-maven</artifactId>
         <version>22.4.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>doc-maven</artifactId>
-    <packaging>pom</packaging>
-
-    <modules>
-        <module>doc-common-content</module>
-        <module>doc-default-branding</module>
-        <module>doc-maven-plugin</module>
-        <module>xcite-maven-plugin</module>
-    </modules>
-
-    <properties>
-        <mavenVersion>3.3.1</mavenVersion>
-        <plexusUtilsVersion>3.5.0</plexusUtilsVersion>
-    </properties>
+    <artifactId>doc-common-content</artifactId>
 </project>

--- a/doc-maven/doc-maven-plugin/pom.xml
+++ b/doc-maven/doc-maven-plugin/pom.xml
@@ -71,13 +71,13 @@
         -->
         <asciidoctorPluginVersion>1.5.2</asciidoctorPluginVersion>
         <brandingVersion>${project.version}</brandingVersion>
-        <commonContentVersion>3.1.0-SNAPSHOT</commonContentVersion>
+        <commonContentVersion>${project.version}</commonContentVersion>
         <docbkxVersion>2.0.16</docbkxVersion>
         <fopHyphVersion>1.2</fopHyphVersion>
         <jCiteVersion>1.13.0</jCiteVersion>
         <linkTesterVersion>1.3.0</linkTesterVersion>
         <plantUmlVersion>7993</plantUmlVersion>
-        <xCiteVersion>1.0.0</xCiteVersion>
+        <xCiteVersion>${project.version}</xCiteVersion>
     </properties>
 
     <dependencyManagement>

--- a/doc-maven/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/pre/XCite.java
+++ b/doc-maven/doc-maven-plugin/src/main/java/org/forgerock/doc/maven/pre/XCite.java
@@ -121,7 +121,7 @@ public class XCite {
 
             executeMojo(
                     plugin(
-                            groupId("org.forgerock.maven.plugins"),
+                            groupId("org.wrensecurity.commons"),
                             artifactId("xcite-maven-plugin"),
                             version(xCiteVersion),
                             dependencies(


### PR DESCRIPTION
Add empty common-content to make doc-maven-plugin builds pass.