### PR TITLE
Upgrade TestNG, Jackson and Guava dependencies

### DIFF
--- a/audit/forgerock-audit-handler-json/src/test/java/org/forgerock/audit/handlers/json/JsonAuditEventHandlerTest.java
+++ b/audit/forgerock-audit-handler-json/src/test/java/org/forgerock/audit/handlers/json/JsonAuditEventHandlerTest.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions copyright 2021 Wren Security.
+ * Portions copyright 2021-2023 Wren Security.
  */
 
 package org.forgerock.audit.handlers.json;
@@ -24,7 +24,7 @@ import static org.forgerock.audit.handlers.json.JsonAuditEventHandler.ROTATE_FIL
 import static org.forgerock.json.JsonValue.*;
 import static org.forgerock.json.JsonValue.field;
 import static org.forgerock.util.test.FileUtils.deleteRecursively;
-import static org.junit.Assert.fail;
+import static org.testng.Assert.fail;
 
 import java.io.InputStream;
 import java.nio.file.DirectoryStream;

--- a/bloomfilter/bloomfilter-core/src/test/java/org/forgerock/bloomfilter/ConcurrentRollingBloomFilterTest.java
+++ b/bloomfilter/bloomfilter-core/src/test/java/org/forgerock/bloomfilter/ConcurrentRollingBloomFilterTest.java
@@ -12,11 +12,13 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015 ForgeRock AS.
+ * Portions copyright 2023 Wren Security
  */
 
 package org.forgerock.bloomfilter;
 
-import junit.framework.Assert;
+import static org.testng.Assert.assertTrue;
+
 import org.wrensecurity.guava.common.hash.Funnels;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -104,7 +106,7 @@ public class ConcurrentRollingBloomFilterTest {
         System.out.printf("Write Time: %s -> %dms%n", impl, (end - start));
 
         for (int i = 0; i < 50000; ++i) {
-            Assert.assertTrue(impl.mightContain("Test" + i));
+            assertTrue(impl.mightContain("Test" + i));
         }
     }
 

--- a/commons-bom/pom.xml
+++ b/commons-bom/pom.xml
@@ -13,7 +13,7 @@
     information: "Portions copyright [year] [name of copyright owner]".
 
     Copyright 2016 ForgeRock AS.
-    Portions Copyright 2017-2021 Wren Security.
+    Portions Copyright 2017-2023 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -42,11 +42,11 @@
         <wrensec-guava.version>18.0.5</wrensec-guava.version>
         <jaxb-osgi.version>2.3.3</jaxb-osgi.version>
         <activation.version>2.0.0</activation.version>
-        <jackson.version>2.12.1</jackson.version>
+        <jackson.version>2.15.2</jackson.version>
         <mockito.version>4.4.0</mockito.version>
         <servlet-api.version>3.1.0</servlet-api.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <testng.version>7.3.0</testng.version>
+        <testng.version>7.8.0</testng.version>
         <swagger.version>1.6.2</swagger.version>
         <jsr305.version>3.0.2</jsr305.version>
     </properties>
@@ -127,13 +127,6 @@
                         <artifactId>animal-sniffer-annotations</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-
-            <!-- Override version managed by testng to version required by jackson-dataformat-yaml -->
-            <dependency>
-              <groupId>org.yaml</groupId>
-              <artifactId>snakeyaml</artifactId>
-              <version>1.27</version>
             </dependency>
 
             <dependency>

--- a/commons-bom/pom.xml
+++ b/commons-bom/pom.xml
@@ -47,7 +47,7 @@
         <servlet-api.version>3.1.0</servlet-api.version>
         <slf4j.version>1.7.30</slf4j.version>
         <testng.version>7.8.0</testng.version>
-        <swagger.version>1.6.2</swagger.version>
+        <swagger.version>1.6.11</swagger.version>
         <jsr305.version>3.0.2</jsr305.version>
     </properties>
 
@@ -96,11 +96,11 @@
                 <version>${slf4j.version}</version>
             </dependency>
 
-            <!-- Override version managed by testng to version required by swagger -->
+            <!-- Upgrade version managed by swagger -->
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>27.0.1-android</version>
+                <version>32.1.2-android</version>
                 <exclusions>
                     <exclusion>
                         <groupId>com.google.code.findbugs</groupId>
@@ -120,11 +120,7 @@
                     </exclusion>
                     <exclusion>
                         <groupId>org.checkerframework</groupId>
-                        <artifactId>checker-compat-qual</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>animal-sniffer-annotations</artifactId>
+                        <artifactId>checker-qual</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/http-framework/http-core/src/test/java/org/forgerock/http/MutableUriTest.java
+++ b/http-framework/http-core/src/test/java/org/forgerock/http/MutableUriTest.java
@@ -508,10 +508,8 @@ public class MutableUriTest {
     @Test
     public void shouldResolveWhenThereIsNoTrailingSlashInBase() throws Exception {
         MutableUri uri = uri("http://www.example.com");
-        MutableUri resolved = uri.resolve(uri("c%3Dd"));
-        // Do not use uri() here because resolution knows %3d is a path element
-        // where http://...comc%3Dd is see as part of the hostname (no path element)
-        assertThat(resolved.toString()).isEqualTo("http://www.example.comc%3Dd");
+        MutableUri resolved = uri.resolve(uri("/c%3Dd"));
+        assertThat(resolved.toString()).isEqualTo("http://www.example.com/c%3Dd");
         assertThat(resolved.getPathElements().toString()).isEqualTo("c=d");
     }
 

--- a/i18n/i18n-slf4j/pom.xml
+++ b/i18n/i18n-slf4j/pom.xml
@@ -13,7 +13,7 @@
    information: "Portions copyright [year] [name of copyright owner]".
 
    Copyright 2011 ForgeRock AS.
-   Portions Copyright 2017-2022 Wren Security.
+   Portions Copyright 2017-2023 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -38,12 +38,10 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>i18n-core</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.6.1</version>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/i18n/i18n-slf4j/src/main/java/org/forgerock/i18n/slf4j/LocalizedMarker.java
+++ b/i18n/i18n-slf4j/src/main/java/org/forgerock/i18n/slf4j/LocalizedMarker.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  *      Copyright 2014 ForgeRock AS
+ * Portions copyright 2023 Wren Security
  */
 package org.forgerock.i18n.slf4j;
 
@@ -84,8 +85,8 @@ public class LocalizedMarker implements Marker {
 
     /** {@inheritDoc} */
     @Override
-    public Iterator<?> iterator() {
-        return Collections.emptySet().iterator();
+    public Iterator<Marker> iterator() {
+        return Collections.<Marker>emptySet().iterator();
     }
 
     /** {@inheritDoc} */

--- a/i18n/pom.xml
+++ b/i18n/pom.xml
@@ -34,8 +34,7 @@
     </description>
 
     <properties>
-        <pgpVerifyKeysVersion>1.6.2</pgpVerifyKeysVersion>
-        <testng.version>7.3.0</testng.version>
+        <testng.version>7.8.0</testng.version>
         <mockito.version>4.4.0</mockito.version>
         <assertj.version>3.23.1</assertj.version>
     </properties>

--- a/json-schema/json-schema-core/pom.xml
+++ b/json-schema/json-schema-core/pom.xml
@@ -13,7 +13,7 @@
     information: "Portions copyright [year] [name of copyright owner]".
 
     Copyright 2012-2015 ForgeRock AS.
-    Portions Copyright 2017-2021 Wren Security.
+    Portions Copyright 2017-2023 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -80,7 +80,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
 
                 <configuration>
-                    <parallel>true</parallel>
+                    <parallel>methods</parallel>
                     <threadCount>10</threadCount>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     </repositories>
 
     <properties>
-        <pgpVerifyKeysVersion>1.7.1</pgpVerifyKeysVersion>
+        <pgpVerifyKeysVersion>1.7.6-SNAPSHOT</pgpVerifyKeysVersion>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     </repositories>
 
     <properties>
-        <pgpVerifyKeysVersion>1.7.6-SNAPSHOT</pgpVerifyKeysVersion>
+        <pgpVerifyKeysVersion>1.7.6</pgpVerifyKeysVersion>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
     </properties>
 

--- a/rest/api-descriptor/src/main/java/org/forgerock/api/jackson/JacksonUtils.java
+++ b/rest/api-descriptor/src/main/java/org/forgerock/api/jackson/JacksonUtils.java
@@ -12,20 +12,12 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions Copyright 2018 Wren Security.
+ * Portions Copyright 2018-2023 Wren Security.
  */
 
 package org.forgerock.api.jackson;
 
 import static org.forgerock.json.JsonValue.json;
-
-import java.io.IOException;
-import java.util.Set;
-
-import javax.validation.ValidationException;
-
-import org.forgerock.http.util.Json;
-import org.forgerock.util.i18n.LocalizableString;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -33,8 +25,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonValueFormat;
 import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
-
 import io.swagger.util.ReferenceSerializationConfigurer;
+import java.io.IOException;
+import java.util.Set;
+import javax.validation.ValidationException;
+import org.forgerock.http.util.Json;
 
 /**
  * Some utilities for working with Jackson, JSON object mapping, and JSON schema.
@@ -44,7 +39,8 @@ public final class JacksonUtils {
      * A public static {@code ObjectMapper} instance, so that they do not have to be instantiated
      * all over the place, as they are expensive to construct.
      */
-    public static final ObjectMapper OBJECT_MAPPER = io.swagger.util.Json.mapper();
+    public static final ObjectMapper OBJECT_MAPPER = io.swagger.util.Json.mapper()
+            .registerModules(new Json.LocalizableStringModule(), new Json.JsonValueModule());
 
     /**
      * Create a Jackson JSON object mapper that is best-suited for general-purpose use by
@@ -56,16 +52,12 @@ public final class JacksonUtils {
      * representation of each object, without any of the tweaks that are normally needed for
      * Swagger output.
      *
-     * <p>Unlike a vanilla {@link ObjectMapper}, the mapper returned by this method is configured to
-     * be able to serialize {@link LocalizableString} instances.
-     *
      * @return
      *  A Jackson {@code ObjectMapper} that can generically handle most POJOs and localize-able
      *  strings.
      */
     public static ObjectMapper createGenericMapper() {
-        final ObjectMapper mapper =
-            new ObjectMapper()
+        final ObjectMapper mapper = new ObjectMapper()
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL)
                 .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
                 .enable(SerializationFeature.INDENT_OUTPUT)

--- a/rest/api-descriptor/src/test/java/org/forgerock/api/ExamplesTest.java
+++ b/rest/api-descriptor/src/test/java/org/forgerock/api/ExamplesTest.java
@@ -12,7 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
- * Portions Copyright 2018 Wren Security.
+ * Portions Copyright 2018-2023 Wren Security.
  */
 
 package org.forgerock.api;
@@ -28,8 +28,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
 import org.forgerock.api.models.ApiDescription;
 import org.forgerock.api.jackson.JacksonUtils;
@@ -40,12 +38,6 @@ public class ExamplesTest {
 
     @BeforeClass
     public void setup() throws Exception {
-        // Unfortunately this currently produces a trivial schema that just has {@code "type": "any"}
-        // for the {@code Errors}, {@code Definitions} and {@code Paths} classes.
-        //
-        // Raised with the jackson project:
-        // - https://github.com/FasterXML/jackson-module-jsonSchema/pull/100
-        // - https://github.com/FasterXML/jackson-databind/pull/1177
         schema = schemaFor(ApiDescription.class);
     }
 

--- a/rest/api-descriptor/src/test/java/org/forgerock/api/models/DefinitionsTest.java
+++ b/rest/api-descriptor/src/test/java/org/forgerock/api/models/DefinitionsTest.java
@@ -12,13 +12,13 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions copyright 2023 Wren Security
  */
 
 package org.forgerock.api.models;
 
 import static org.assertj.core.api.Assertions.*;
 
-import org.forgerock.json.JsonValue;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -26,7 +26,7 @@ public class DefinitionsTest {
 
     private static final Schema OBJECT_SCHEMA = Schema.schema().type(Object.class).build();
     private static final Schema OTHER_EQUAL_SCHEMA = Schema.schema().type(Object.class).build();
-    private static final Schema OTHER_NON_EQUAL_SCHEMA = Schema.schema().type(JsonValue.class).build();
+    private static final Schema OTHER_NON_EQUAL_SCHEMA = Schema.schema().type(String.class).build();
 
 
     @DataProvider(name = "putValidationData")

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -13,7 +13,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2012-2016 ForgeRock AS.
-  Portions Copyright 2017-2018 Wren Security.
+  Portions Copyright 2017-2023 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -64,16 +64,16 @@
         </dependency>
 
         <dependency>
-            <groupId>org.forgerock.opendj</groupId>
+            <groupId>org.wrensecurity.wrends</groupId>
             <artifactId>opendj-ldap-toolkit</artifactId>
-            <version>4.0.0-M3</version>
+            <version>5.0.1</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
-                    <groupId>org.forgerock.commons</groupId>
+                    <groupId>org.wrensecurity.commons</groupId>
                     <artifactId>forgerock-util</artifactId>
                 </exclusion>
-            </exclusions> 
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/self-service/forgerock-selfservice-core/src/main/java/org/forgerock/selfservice/core/config/ClassNameFallbackPropertyTypeDeserializer.java
+++ b/self-service/forgerock-selfservice-core/src/main/java/org/forgerock/selfservice/core/config/ClassNameFallbackPropertyTypeDeserializer.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions copyright 2023 Wren Security
  */
 package org.forgerock.selfservice.core.config;
 
@@ -59,9 +60,9 @@ class ClassNameFallbackPropertyTypeDeserializer extends AsPropertyTypeDeserializ
      */
     @Override
     protected Object _deserializeTypedUsingDefaultImpl(JsonParser jsonParser, DeserializationContext context,
-            TokenBuffer tokenBuffer) throws IOException {
+            TokenBuffer tokenBuffer, String priorFailureMsg) throws IOException {
         try {
-            return super._deserializeTypedUsingDefaultImpl(jsonParser, context, tokenBuffer);
+            return super._deserializeTypedUsingDefaultImpl(jsonParser, context, tokenBuffer, priorFailureMsg);
         } catch (JsonMappingException e) {
             // fallback
             if (tokenBuffer != null) {

--- a/self-service/forgerock-selfservice-example-ui/pom.xml
+++ b/self-service/forgerock-selfservice-example-ui/pom.xml
@@ -13,7 +13,7 @@
     information: "Portions copyright [year] [name of copyright owner]".
 
     Copyright (c) 2015 ForgeRock AS. All Rights Reserved
-    Portions Copyright 2017-2021 Wren Security.
+    Portions Copyright 2017-2023 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -31,7 +31,7 @@
     <description>UI for Wren Security Self-Service Example</description>
 
     <properties>
-        <forgerock-ui.version>22.0.0-M2</forgerock-ui.version>
+        <forgerock-ui.version>22.1.2</forgerock-ui.version>
     </properties>
 
     <build>


### PR DESCRIPTION
This PR upgrades TestNG, Jackson and Guava dependencies to resolve the security vulnerabilities published as a [CVE-2022-1471](https://nvd.nist.gov/vuln/detail/CVE-2022-1471), [CVE-2020-36518](https://nvd.nist.gov/vuln/detail/CVE-2020-36518) and [CVE-2023-2976](https://nvd.nist.gov/vuln/detail/CVE-2023-2976).