### PR TITLE
Fix NPE when preferred locales are missing.

### DIFF
--- a/self-service/forgerock-selfservice-stages/src/main/java/org/forgerock/selfservice/stages/utils/LocaleUtils.java
+++ b/self-service/forgerock-selfservice-stages/src/main/java/org/forgerock/selfservice/stages/utils/LocaleUtils.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2017 ForgeRock AS.
+ * Portions Copyright 2023 Wren Security.
  */
 
 package org.forgerock.selfservice.stages.utils;
@@ -74,13 +75,15 @@ public final class LocaleUtils {
                 Locale.forLanguageTag(System.getProperty("org.forgerock.selfservice.defaultLocale", "en-US"));
         boolean defaultsAdded = false;
         List<Locale> locales = new ArrayList<>();
-        for (Locale locale : preferredLocales.getLocales()) {
-            if (locale.equals(Locale.ROOT) && !defaultsAdded) {
-                locales.add(defaultLocale);
-                locales.add(Locale.getDefault());
-                defaultsAdded = true;
-            } else if (!locale.equals(Locale.ROOT)) {
-                locales.add(locale);
+        if (preferredLocales != null) {
+            for (Locale locale : preferredLocales.getLocales()) {
+                if (locale.equals(Locale.ROOT) && !defaultsAdded) {
+                    locales.add(defaultLocale);
+                    locales.add(Locale.getDefault());
+                    defaultsAdded = true;
+                } else if (!locale.equals(Locale.ROOT)) {
+                    locales.add(locale);
+                }
             }
         }
         if (!defaultsAdded) {


### PR DESCRIPTION
This PR fixes NPE when no preferred locales are specified. This occurs when the CREST request is built directly (e.g. [ResourceFunctions.java#L943](https://github.com/WrenSecurity/wrenidm/blob/2a4d5bd0639d48b3b7ad1883d0a8c7ea710647a0/openidm-script/src/main/java/org/forgerock/openidm/script/ResourceFunctions.java#L943)) and locale is not set in `HttpAdapter` component ([HttpAdapter.java#L739](https://github.com/WrenSecurity/wrensec-commons/blob/40607e8c71047d38cd8d107f495e1168ca8963c5/rest/json-resource-http/src/main/java/org/forgerock/json/resource/http/HttpAdapter.java#L739)).