### PR TITLE
 Ignore NTLM in IWA module

### DIFF
--- a/auth-filters/forgerock-authn-filter/forgerock-jaspi-modules/forgerock-jaspi-iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/IWAModule.java
+++ b/auth-filters/forgerock-authn-filter/forgerock-jaspi-modules/forgerock-jaspi-iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/IWAModule.java
@@ -103,6 +103,11 @@ public class IWAModule implements AsyncServerAuthModule {
             return newExceptionPromise(new AuthenticationException("Invalid SPNEGO token"));
         }
 
+        // Ignore NTLM over SPNEGO
+        if (spnegoToken[0] == 'N' && spnegoToken[1] == 'T' && spnegoToken[2] == 'L' && spnegoToken[3] == 'M') {
+            return newResultPromise(SEND_FAILURE);
+        }
+
         // Perform Kerberos authentication
         try {
             final String username = new WDSSO().process(options, messageInfo, spnegoToken);

--- a/auth-filters/forgerock-authn-filter/forgerock-jaspi-modules/forgerock-jaspi-iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/IWAModule.java
+++ b/auth-filters/forgerock-authn-filter/forgerock-jaspi-modules/forgerock-jaspi-iwa-module/src/main/java/org/forgerock/jaspi/modules/iwa/IWAModule.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2016 ForgeRock AS.
+ * Portions Copyright 2024 Wren Security
  */
 
 package org.forgerock.jaspi.modules.iwa;
@@ -23,13 +24,11 @@ import static org.forgerock.util.promise.Promises.newResultPromise;
 
 import javax.security.auth.Subject;
 import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.message.AuthException;
 import javax.security.auth.message.AuthStatus;
 import javax.security.auth.message.MessagePolicy;
 import java.security.Principal;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.forgerock.caf.authentication.api.AsyncServerAuthModule;
@@ -38,6 +37,7 @@ import org.forgerock.caf.authentication.api.MessageInfoContext;
 import org.forgerock.http.protocol.Request;
 import org.forgerock.http.protocol.Response;
 import org.forgerock.http.protocol.Status;
+import org.forgerock.jaspi.modules.iwa.wdsso.Base64;
 import org.forgerock.jaspi.modules.iwa.wdsso.WDSSO;
 import org.forgerock.util.promise.Promise;
 
@@ -49,106 +49,100 @@ import org.forgerock.util.promise.Promise;
 public class IWAModule implements AsyncServerAuthModule {
 
     private static final String IWA_FAILED = "iwa-failed";
+    private static final String NEGOTIATE_AUTH_SCHEME = "Negotiate";
 
-    private CallbackHandler handler;
-    private Map options;
+    private Map<String, Object> options;
 
     @Override
     public String getModuleId() {
         return "IWA";
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void initialize(MessagePolicy requestPolicy, MessagePolicy responsePolicy, CallbackHandler handler,
             Map<String, Object> options) throws AuthenticationException {
-        this.handler = handler;
         this.options = options;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Collection<Class<?>> getSupportedMessageTypes() {
-        return Arrays.asList(new Class<?>[]{Request.class, Response.class});
+        return Arrays.asList(new Class<?>[]{ Request.class, Response.class });
     }
 
     /**
      * Validates the request by checking the Authorization header in the request for a IWA token and processes that
      * for authentication.
-     *
-     * @param messageInfo {@inheritDoc}
-     * @param clientSubject {@inheritDoc}
-     * @param serviceSubject {@inheritDoc}
-     * @return {@inheritDoc}
      */
     @Override
     public Promise<AuthStatus, AuthenticationException> validateRequest(MessageInfoContext messageInfo,
             Subject clientSubject, Subject serviceSubject) {
-
-        LOG.debug("IWAModule: validateRequest START");
-
         Request request = messageInfo.getRequest();
         Response response = messageInfo.getResponse();
 
-        String httpAuthorization = request.getHeaders().getFirst("Authorization");
+        String authorizationHeader = request.getHeaders().getFirst("Authorization");
 
+        if (authorizationHeader == null || authorizationHeader.isEmpty()) {
+            LOG.debug("IWAModule: Authorization Header NOT set in request.");
+
+            response.getHeaders().put("WWW-Authenticate", NEGOTIATE_AUTH_SCHEME);
+            response.setStatus(Status.UNAUTHORIZED);
+            response.setEntity(Map.of("failure", true, "recason", IWA_FAILED));
+            return newResultPromise(SEND_CONTINUE);
+        }
+
+        // Handle only negotiate authentication requests
+        if (!authorizationHeader.startsWith(NEGOTIATE_AUTH_SCHEME)) {
+            return newResultPromise(SEND_FAILURE);
+        }
+
+        LOG.debug("IWAModule: Negotiate authorization header set in request.");
+
+        // Check SPNEGO token
+        byte[] spnegoToken = extractSpnegoToken(authorizationHeader);
+        if (spnegoToken == null) {
+            return newExceptionPromise(new AuthenticationException("Invalid SPNEGO token"));
+        }
+
+        // Perform Kerberos authentication
         try {
-            if (httpAuthorization == null || "".equals(httpAuthorization)) {
-                LOG.debug("IWAModule: Authorization Header NOT set in request.");
+            final String username = new WDSSO().process(options, messageInfo, spnegoToken);
+            LOG.debug("IWAModule: IWA successful with username, {}", username);
 
-                response.getHeaders().put("WWW-Authenticate", "Negotiate");
-                response.setStatus(Status.UNAUTHORIZED);
-                Map<String, Object> entity = new HashMap<>();
-                entity.put("failure", true);
-                entity.put("recason", IWA_FAILED);
-                response.setEntity(entity);
-
-                return newResultPromise(SEND_CONTINUE);
-            } else {
-                LOG.debug("IWAModule: Authorization Header set in request.");
-                try {
-                    final String username = new WDSSO().process(options, messageInfo, request);
-                    LOG.debug("IWAModule: IWA successful with username, {}", username);
-
-                    clientSubject.getPrincipals().add(new Principal() {
-                        public String getName() {
-                            return username;
-                        }
-                    });
-                } catch (Exception e) {
-                    LOG.debug("IWAModule: IWA has failed. {}", e.getMessage());
-                    return newExceptionPromise(new AuthenticationException("IWA has failed"));
+            clientSubject.getPrincipals().add(new Principal() {
+                @Override
+                public String getName() {
+                    return username;
                 }
-
-                return newResultPromise(SUCCESS);
-            }
-        } finally {
-            LOG.debug("IWAModule: validateRequest END");
+            });
+            return newResultPromise(SUCCESS);
+        } catch (Exception e) {
+            LOG.debug("IWAModule: IWA has failed. {}", e.getMessage());
+            return newExceptionPromise(new AuthenticationException("IWA has failed"));
         }
     }
 
-    /**
-     * Always returns AuthStatus.SEND_SUCCESS.
-     *
-     * @param messageInfo {@inheritDoc}
-     * @param serviceSubject {@inheritDoc}
-     * @return {@inheritDoc}
-     */
     @Override
-    public Promise<AuthStatus, AuthenticationException> secureResponse(MessageInfoContext messageInfo,
-            Subject serviceSubject) {
+    public Promise<AuthStatus, AuthenticationException> secureResponse(MessageInfoContext messageInfo, Subject serviceSubject) {
         return newResultPromise(SEND_SUCCESS);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Promise<Void, AuthenticationException> cleanSubject(MessageInfoContext messageInfo, Subject subject) {
         return newResultPromise(null);
     }
+
+    /**
+     * Extract SPNEGO token from the specified negotiate authorization header.
+     * @param header Authorization header to extract SPNEGO token.
+     * @return Extracted token or null when extraction fails.
+     */
+    private byte[] extractSpnegoToken(String header) {
+        try {
+            return Base64.decode(header.substring(NEGOTIATE_AUTH_SCHEME.length()).trim());
+        } catch (Exception e) {
+            LOG.error("IWAModule: Failed to extract SPNEGO token from authorization header");
+            return null;
+        }
+    }
+
 }


### PR DESCRIPTION
This PR fixes #55. It introduces ignoring of non-negotiate and NTLM requests to the IWA authentication module.