### PR TITLE
Upgrade jetty dependency

### DIFF
--- a/commons-bom/pom.xml
+++ b/commons-bom/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wrensecurity</groupId>
         <artifactId>wrensec-parent</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.2</version>
         <relativePath />
     </parent>
 

--- a/http-framework/http-servlet/pom.xml
+++ b/http-framework/http-servlet/pom.xml
@@ -94,14 +94,14 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>8.1.15.v20140411</version>
+      <version>10.0.24</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>8.1.15.v20140411</version>
+      <version>10.0.24</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/http-framework/http-servlet/src/test/java/org/forgerock/http/servlet/ServletTest.java
+++ b/http-framework/http-servlet/src/test/java/org/forgerock/http/servlet/ServletTest.java
@@ -12,9 +12,11 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions Copyright 2025 Wren Security.
  */
 package org.forgerock.http.servlet;
 
+import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
@@ -37,7 +39,7 @@ public class ServletTest extends BindingTest {
     @Override
     protected int startServer() throws Exception {
         server.start();
-        return server.getConnectors()[0].getLocalPort();
+        return ((NetworkConnector) server.getConnectors()[0]).getLocalPort();
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wrensecurity</groupId>
         <artifactId>wrensec-parent</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.2</version>
         <relativePath />
     </parent>
 
@@ -88,7 +88,6 @@
     </repositories>
 
     <properties>
-        <pgpVerifyKeysVersion>1.7.6</pgpVerifyKeysVersion>
         <wrenBuildToolsVersion>1.2.0</wrenBuildToolsVersion>
         <pmdPluginVersion>3.21.2</pmdPluginVersion>
         <jxrPluginVersion>3.3.2</jxrPluginVersion>


### PR DESCRIPTION
This PR updates the Jetty dependency to fix a problem with revoked PGP key.