### PR TITLE
Bump SLF4J version

### DIFF
--- a/bloomfilter/pom.xml
+++ b/bloomfilter/pom.xml
@@ -13,7 +13,7 @@
    information: "Portions copyright [year] [name of copyright owner]".
 
    Copyright 2015 ForgeRock AS.
-   Portions Copyright 2023 Wren Security.
+   Portions Copyright 2023-2025 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -46,7 +46,7 @@
         <hdrhistogram.version>2.1.4</hdrhistogram.version>
 <!--
         <jsr.305.version>3.0.0</jsr.305.version>
-        <slf4j.version>1.7.5</slf4j.version>
+        <slf4j.version>2.0.17</slf4j.version>
         <assertj.version>1.6.1</assertj.version>
         <mockito.version>1.9.5</mockito.version>
         <testng.version>6.0.1</testng.version>

--- a/commons-bom/pom.xml
+++ b/commons-bom/pom.xml
@@ -13,7 +13,7 @@
     information: "Portions copyright [year] [name of copyright owner]".
 
     Copyright 2016 ForgeRock AS.
-    Portions Copyright 2017-2023 Wren Security.
+    Portions Copyright 2017-2025 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -52,7 +52,7 @@
         <jackson.version>2.15.2</jackson.version>
         <mockito.version>4.4.0</mockito.version>
         <servlet-api.version>5.0.0</servlet-api.version>
-        <slf4j.version>1.7.30</slf4j.version>
+        <slf4j.version>2.0.17</slf4j.version>
         <testng.version>7.8.0</testng.version>
         <swagger.version>1.6.11</swagger.version>
         <jsr305.version>3.0.2</jsr305.version>

--- a/guice/pom.xml
+++ b/guice/pom.xml
@@ -100,7 +100,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-nop</artifactId>
-                <version>1.7.12</version>
+                <version>2.0.17</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     </repositories>
 
     <properties>
-        <pgpVerifyKeysVersion>1.8.5-SNAPSHOT</pgpVerifyKeysVersion>
+        <pgpVerifyKeysVersion>1.9.0</pgpVerifyKeysVersion>
         <wrenBuildToolsVersion>1.2.0</wrenBuildToolsVersion>
         <pmdPluginVersion>3.21.2</pmdPluginVersion>
         <jxrPluginVersion>3.3.2</jxrPluginVersion>


### PR DESCRIPTION
Bumps the SLF4J dependency to version 2.0.17. This allows us to use the new ServiceLoader mechanism and other new features within Wren:AM.