### PR TITLE
Fix JSON Crypto incorrect AES key size assumption

### DIFF
--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [11, 17]
+        java: [11, 17, 21]
     name: "Java ${{ matrix.java }} build"
     steps:
       - name: Checkout project

--- a/http-framework/pom.xml
+++ b/http-framework/pom.xml
@@ -77,7 +77,7 @@
       <dependency>
         <groupId>org.codehaus.groovy</groupId>
         <artifactId>groovy-jsr223</artifactId>
-        <version>3.0.10</version>
+        <version>3.0.25</version>
       </dependency>
 
       <dependency>

--- a/json-crypto/json-crypto-core/src/main/java/org/forgerock/json/crypto/simple/SimpleDecryptor.java
+++ b/json-crypto/json-crypto-core/src/main/java/org/forgerock/json/crypto/simple/SimpleDecryptor.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyrighted [year] [name of copyright owner]".
  *
  * Copyright 2011-2015 ForgeRock AS.
+ * Portions Copyrighted 2025 Wren Security
  */
 
 package org.forgerock.json.crypto.simple;
@@ -106,7 +107,7 @@ public class SimpleDecryptor implements JsonDecryptor {
                 }
 
                 symmetricKey = HKDFKeyGenerator.expandKey(masterKey, symmetricKey.getAlgorithm(),
-                        SimpleEncryptor.ASYMMETRIC_AES_KEY_SIZE);
+                        key.isString() ? symmetricKey.getEncoded().length : SimpleEncryptor.ASYMMETRIC_AES_KEY_SIZE);
             }
 
             Cipher symmetric = Cipher.getInstance(cipher);


### PR DESCRIPTION
New Java 21 (Temurin at least) changes default AES key size from 128 to 256. This fixes `JsonDecryptor` that incorrectly uses key size for asymetric encryption.

The other commit simply adds Java 21 to our GitHub build workflow.