### PR TITLE
Remove external dependencies from commons BOM

### DIFF
--- a/audit/forgerock-audit-benchmark/pom.xml
+++ b/audit/forgerock-audit-benchmark/pom.xml
@@ -59,17 +59,20 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-audit-handler-csv</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-audit-handler-json</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- test dependencies -->
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-test-utils</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/audit/forgerock-audit-core/pom.xml
+++ b/audit/forgerock-audit-core/pom.xml
@@ -61,11 +61,13 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>security</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Test Dependencies -->
@@ -90,12 +92,14 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-test-utils</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource-http</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/audit/forgerock-audit-handler-csv/pom.xml
+++ b/audit/forgerock-audit-handler-csv/pom.xml
@@ -56,28 +56,33 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-audit-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>security</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-audit-json</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-test-utils</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/audit/forgerock-audit-handler-elasticsearch/pom.xml
+++ b/audit/forgerock-audit-handler-elasticsearch/pom.xml
@@ -46,16 +46,19 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-audit-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.http</groupId>
             <artifactId>chf-client-apache-async</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Test Dependencies -->
@@ -80,18 +83,21 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-test-utils</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource-http</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-audit-json</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/audit/forgerock-audit-handler-jdbc/pom.xml
+++ b/audit/forgerock-audit-handler-jdbc/pom.xml
@@ -62,23 +62,27 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-audit-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-audit-json</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-test-utils</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/audit/forgerock-audit-handler-jms/pom.xml
+++ b/audit/forgerock-audit-handler-jms/pom.xml
@@ -62,6 +62,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -81,6 +82,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-test-utils</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/audit/forgerock-audit-handler-json/pom.xml
+++ b/audit/forgerock-audit-handler-json/pom.xml
@@ -46,11 +46,13 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-audit-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Test Dependencies -->
@@ -75,12 +77,14 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-test-utils</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-audit-json</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/audit/forgerock-audit-handler-splunk/pom.xml
+++ b/audit/forgerock-audit-handler-splunk/pom.xml
@@ -36,16 +36,19 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-audit-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.http</groupId>
             <artifactId>chf-client-apache-async</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/audit/forgerock-audit-handler-syslog/pom.xml
+++ b/audit/forgerock-audit-handler-syslog/pom.xml
@@ -56,23 +56,27 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-audit-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-audit-json</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-test-utils</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/audit/forgerock-audit-json/pom.xml
+++ b/audit/forgerock-audit-json/pom.xml
@@ -52,11 +52,13 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-audit-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/audit/forgerock-audit-servlet/pom.xml
+++ b/audit/forgerock-audit-servlet/pom.xml
@@ -39,36 +39,43 @@
         <dependency>
             <groupId>org.wrensecurity.http</groupId>
             <artifactId>chf-http-servlet</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource-http</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-audit-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-audit-handler-csv</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-audit-handler-syslog</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-audit-handler-jdbc</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -96,6 +103,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-audit-json</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -112,6 +120,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-test-utils</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/auth-filters/forgerock-authn-filter/forgerock-jaspi-functional-tests/pom.xml
+++ b/auth-filters/forgerock-authn-filter/forgerock-jaspi-functional-tests/pom.xml
@@ -128,16 +128,19 @@
         <dependency>
             <groupId>org.wrensecurity.http</groupId>
             <artifactId>chf-http-servlet</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.http</groupId>
             <artifactId>chf-http-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource-http</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/auth-filters/forgerock-authn-filter/forgerock-jaspi-modules/forgerock-jaspi-jwt-session-module/pom.xml
+++ b/auth-filters/forgerock-authn-filter/forgerock-jaspi-modules/forgerock-jaspi-jwt-session-module/pom.xml
@@ -57,11 +57,13 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-web-token</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>security</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <!-- Included only to allow building the Cookie class. Do not use APIs not present in 2.5 -->

--- a/auth-filters/forgerock-authn-filter/forgerock-jaspi-modules/forgerock-jaspi-openam-session-module/pom.xml
+++ b/auth-filters/forgerock-authn-filter/forgerock-jaspi-modules/forgerock-jaspi-openam-session-module/pom.xml
@@ -62,16 +62,19 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-util</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>security</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.http</groupId>
             <artifactId>chf-http-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/auth-filters/forgerock-authn-filter/forgerock-jaspi-modules/forgerock-jaspi-openid-connect-module/pom.xml
+++ b/auth-filters/forgerock-authn-filter/forgerock-jaspi-modules/forgerock-jaspi-openid-connect-module/pom.xml
@@ -57,11 +57,13 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-web-token</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>security</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/auth-filters/forgerock-authn-filter/forgerock-jaspi-runtime/pom.xml
+++ b/auth-filters/forgerock-authn-filter/forgerock-jaspi-runtime/pom.xml
@@ -63,11 +63,13 @@
         <dependency>
             <groupId>org.wrensecurity.http</groupId>
             <artifactId>chf-http-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency> <!-- Required for JsonValue and ResourceException -->
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency> <!-- Required for MediaType in FailureResponseHandler -->

--- a/auth-filters/forgerock-authz-filter-parent/authz-framework-api/pom.xml
+++ b/auth-filters/forgerock-authz-filter-parent/authz-framework-api/pom.xml
@@ -33,6 +33,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/auth-filters/forgerock-authz-filter-parent/authz-framework-functional-tests/pom.xml
+++ b/auth-filters/forgerock-authz-filter-parent/authz-framework-functional-tests/pom.xml
@@ -200,11 +200,13 @@
         <dependency>
             <groupId>org.wrensecurity.http</groupId>
             <artifactId>chf-http-servlet</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource-http</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/auth-filters/forgerock-authz-filter-parent/authz-framework/pom.xml
+++ b/auth-filters/forgerock-authz-filter-parent/authz-framework/pom.xml
@@ -39,6 +39,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource</artifactId>
+            <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
 

--- a/auth-filters/forgerock-authz-filter-parent/forgerock-authz-modules/forgerock-authz-oauth2-module/pom.xml
+++ b/auth-filters/forgerock-authz-filter-parent/forgerock-authz-modules/forgerock-authz-oauth2-module/pom.xml
@@ -38,11 +38,13 @@
         <dependency>
             <groupId>org.wrensecurity.http</groupId>
             <artifactId>chf-http-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource-http</artifactId>
+            <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
 

--- a/auth-filters/pom.xml
+++ b/auth-filters/pom.xml
@@ -108,6 +108,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-test-utils</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/bloomfilter/bloomfilter-core/pom.xml
+++ b/bloomfilter/bloomfilter-core/pom.xml
@@ -32,6 +32,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-util</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/commons-bom/pom.xml
+++ b/commons-bom/pom.xml
@@ -44,213 +44,246 @@
     </distributionManagement>
 
     <properties>
-        <jodaTime.version>2.10.9</jodaTime.version>
-        <assertj.version>3.19.0</assertj.version>
         <wrensec-guava.version>18.0.5</wrensec-guava.version>
-        <jaxb-osgi.version>2.3.3</jaxb-osgi.version>
-        <activation.version>2.0.0</activation.version>
-        <jackson.version>2.15.2</jackson.version>
-        <mockito.version>4.4.0</mockito.version>
-        <servlet-api.version>5.0.0</servlet-api.version>
-        <slf4j.version>2.0.17</slf4j.version>
-        <testng.version>7.8.0</testng.version>
-        <swagger.version>1.6.11</swagger.version>
-        <jsr305.version>3.0.2</jsr305.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
-            <!-- Third party dependencies -->
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-jdk14</artifactId>
-                <version>${slf4j.version}</version>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>api-descriptor</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${slf4j.version}</version>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>authz-framework</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-nop</artifactId>
-                <version>${slf4j.version}</version>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>authz-framework-api</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-simple</artifactId>
-                <version>${slf4j.version}</version>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-audit-core</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>jul-to-slf4j</artifactId>
-                <version>${slf4j.version}</version>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-audit-handler-csv</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>jcl-over-slf4j</artifactId>
-                <version>${slf4j.version}</version>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-audit-handler-elasticsearch</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>log4j-over-slf4j</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-
-            <!-- Upgrade version managed by swagger -->
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>32.1.2-android</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.google.code.findbugs</groupId>
-                        <artifactId>jsr305</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.google.errorprone</groupId>
-                        <artifactId>error_prone_annotations</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.google.guava</groupId>
-                        <artifactId>listenablefuture</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.google.j2objc</groupId>
-                        <artifactId>j2objc-annotations</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.checkerframework</groupId>
-                        <artifactId>checker-qual</artifactId>
-                    </exclusion>
-                </exclusions>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-audit-handler-jdbc</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.testng</groupId>
-                <artifactId>testng</artifactId>
-                <version>${testng.version}</version>
-                <scope>test</scope>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-audit-handler-jms</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>${mockito.version}</version>
-                <scope>test</scope>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-audit-handler-json</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>org.assertj</groupId>
-                <artifactId>assertj-core</artifactId>
-                <version>${assertj.version}</version>
-                <scope>test</scope>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-audit-handler-splunk</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-audit-handler-syslog</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-audit-json</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-core</artifactId>
-                <version>${jackson.version}</version>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-authz-oauth2-module</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>com.fasterxml.jackson.module</groupId>
-                <artifactId>jackson-module-jsonSchema</artifactId>
-                <version>${jackson.version}</version>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-authz-oauth2-restlet</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-csv</artifactId>
-                <version>${jackson.version}</version>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-jaspi-iwa-module</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-json-org</artifactId>
-                <version>${jackson.version}</version>
-
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.json</groupId>
-                        <artifactId>json</artifactId>
-                    </exclusion>
-                </exclusions>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-jaspi-jwt-session-module</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>com.fasterxml.jackson.module</groupId>
-                <artifactId>jackson-module-afterburner</artifactId>
-                <version>${jackson.version}</version>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-jaspi-openam-session-module</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-xml</artifactId>
-                <version>${jackson.version}</version>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-jaspi-openid-connect-module</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>com.fasterxml.jackson.module</groupId>
-                <artifactId>jackson-module-jaxb-annotations</artifactId>
-                <version>${jackson.version}</version>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-jaspi-runtime</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-yaml</artifactId>
-                <version>${jackson.version}</version>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-rest-docbook</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-joda</artifactId>
-                <version>${jackson.version}</version>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-selfservice-core</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>com.sun.xml.bind</groupId>
-                <artifactId>jaxb-osgi</artifactId>
-                <version>${jaxb-osgi.version}</version>
-                <exclusions>
-                    <exclusion>
-                      <groupId>com.sun.activation</groupId>
-                      <artifactId>jakarta.activation</artifactId>
-                    </exclusion>
-              </exclusions>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-selfservice-json</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
-              <groupId>jakarta.activation</groupId>
-              <artifactId>jakarta.activation-api</artifactId>
-              <version>${activation.version}</version>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-selfservice-stages</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>jsr305</artifactId>
-                <version>${jsr305.version}</version>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-test-utils</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
-            <!-- Wren Security Guava dependency -->
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>forgerock-util</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>i18n-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>json-crypto-cli</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>json-crypto-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>json-patch</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>json-ref-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>json-resource</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>json-resource</artifactId>
+                <version>${project.version}</version>
+                <type>test-jar</type>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>json-resource-descriptor</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>json-resource-examples</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>json-resource-http</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>json-schema-cli</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>json-schema-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>json-web-token</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons</groupId>
+                <artifactId>security</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.wrensecurity.commons.guava</groupId>
                 <artifactId>wrensec-guava</artifactId>
@@ -347,20 +380,6 @@
                 <version>${wrensec-guava.version}</version>
             </dependency>
 
-            <!-- ForgeRock Util dependencies -->
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-util</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-test-utils</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <!-- ForgeRock HTTP Framework dependencies -->
             <dependency>
                 <groupId>org.wrensecurity.http</groupId>
                 <artifactId>chf-client-apache-async</artifactId>
@@ -387,13 +406,13 @@
 
             <dependency>
                 <groupId>org.wrensecurity.http</groupId>
-                <artifactId>chf-http-servlet</artifactId>
+                <artifactId>chf-http-grizzly</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.wrensecurity.http</groupId>
-                <artifactId>chf-http-grizzly</artifactId>
+                <artifactId>chf-http-servlet</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
@@ -401,282 +420,6 @@
                 <groupId>org.wrensecurity.http</groupId>
                 <artifactId>chf-oauth2</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-
-            <!-- ForgeRock json-* dependencies -->
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>json-crypto-core</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>json-crypto-cli</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>json-patch</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>json-ref-core</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>json-schema-core</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>json-schema-cli</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>json-web-token</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <!-- ForgeRock REST dependencies -->
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>json-resource-descriptor</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>json-resource</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>json-resource</artifactId>
-                <version>${project.version}</version>
-                <type>test-jar</type>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>json-resource-http</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>json-resource-examples</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>api-descriptor</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>i18n-core</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <!-- ForgeRock Auth filters dependencies -->
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-jaspi-iwa-module</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-jaspi-jwt-session-module</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-jaspi-openam-session-module</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-jaspi-openid-connect-module</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-jaspi-runtime</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>authz-framework</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>authz-framework-api</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-authz-oauth2-module</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-authz-oauth2-restlet</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <!-- ForgeRock Audit dependencies -->
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-audit-core</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-audit-json</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-audit-handler-csv</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-audit-handler-elasticsearch</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-audit-handler-json</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-audit-handler-jdbc</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-audit-handler-jms</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-audit-handler-syslog</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-audit-handler-splunk</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>joda-time</groupId>
-                <artifactId>joda-time</artifactId>
-                <version>${jodaTime.version}</version>
-            </dependency>
-
-            <!-- ForgeRock User Self-Service dependencies -->
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-selfservice-core</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-selfservice-stages</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-selfservice-json</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <!-- ForgeRock Security Dependencies -->
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>security</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <!-- ForgeRock Documentation Sources -->
-            <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>forgerock-rest-docbook</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>jakarta.servlet</groupId>
-                <artifactId>jakarta.servlet-api</artifactId>
-                <version>${servlet-api.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.swagger</groupId>
-                <artifactId>swagger-models</artifactId>
-                <version>${swagger.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.swagger</groupId>
-                <artifactId>swagger-core</artifactId>
-                <version>${swagger.version}</version>
-
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                        <artifactId>jackson-annotations</artifactId>
-                    </exclusion>
-
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                        <artifactId>jackson-databind</artifactId>
-                    </exclusion>
-
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.datatype</groupId>
-                        <artifactId>jackson-datatype-joda</artifactId>
-                    </exclusion>
-
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.dataformat</groupId>
-                        <artifactId>jackson-dataformat-yaml</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/http-framework/binding-test-utils/pom.xml
+++ b/http-framework/binding-test-utils/pom.xml
@@ -31,6 +31,7 @@
         <dependency>
             <groupId>org.wrensecurity.http</groupId>
             <artifactId>chf-http-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -42,11 +43,13 @@
         <dependency>
             <groupId>org.wrensecurity.http</groupId>
             <artifactId>chf-client-apache-sync</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-test-utils</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/http-framework/http-benchmarks/pom.xml
+++ b/http-framework/http-benchmarks/pom.xml
@@ -48,6 +48,7 @@
     <dependency>
       <groupId>org.wrensecurity.http</groupId>
       <artifactId>chf-http-core</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/http-framework/http-client-apache-async/pom.xml
+++ b/http-framework/http-client-apache-async/pom.xml
@@ -53,6 +53,7 @@
     <dependency>
       <groupId>org.wrensecurity.http</groupId>
       <artifactId>chf-http-core</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
@@ -77,6 +78,7 @@
     <dependency>
       <groupId>org.wrensecurity.http</groupId>
       <artifactId>chf-client-apache-common</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/http-framework/http-client-apache-common/pom.xml
+++ b/http-framework/http-client-apache-common/pom.xml
@@ -54,6 +54,7 @@
     <dependency>
       <groupId>org.wrensecurity.http</groupId>
       <artifactId>chf-http-core</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <!-- This dependency is inherited by both the synchronous and asynchronous AHC CHF Drivers.

--- a/http-framework/http-client-apache-sync/pom.xml
+++ b/http-framework/http-client-apache-sync/pom.xml
@@ -50,11 +50,13 @@
     <dependency>
       <groupId>org.wrensecurity.http</groupId>
       <artifactId>chf-http-core</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.wrensecurity.http</groupId>
       <artifactId>chf-client-apache-common</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/http-framework/http-client-test-utils/pom.xml
+++ b/http-framework/http-client-test-utils/pom.xml
@@ -33,6 +33,7 @@
         <dependency>
             <groupId>org.wrensecurity.http</groupId>
             <artifactId>chf-http-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -44,6 +45,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-test-utils</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/http-framework/http-core/pom.xml
+++ b/http-framework/http-core/pom.xml
@@ -52,6 +52,7 @@
     <dependency>
       <groupId>org.wrensecurity.commons</groupId>
       <artifactId>forgerock-util</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
@@ -95,6 +96,7 @@
     <dependency>
       <groupId>org.wrensecurity.commons</groupId>
       <artifactId>forgerock-test-utils</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/http-framework/http-examples/http-descriptor-example/pom.xml
+++ b/http-framework/http-examples/http-descriptor-example/pom.xml
@@ -31,6 +31,7 @@
         <dependency>
             <groupId>org.wrensecurity.http</groupId>
             <artifactId>chf-http-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/http-framework/http-examples/http-servlet-example/pom.xml
+++ b/http-framework/http-examples/http-servlet-example/pom.xml
@@ -41,6 +41,7 @@
     <dependency>
       <groupId>org.wrensecurity.http</groupId>
       <artifactId>chf-http-servlet</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/http-framework/http-grizzly/pom.xml
+++ b/http-framework/http-grizzly/pom.xml
@@ -57,6 +57,7 @@
     <dependency>
       <groupId>org.wrensecurity.http</groupId>
       <artifactId>chf-http-core</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/http-framework/http-oauth2/pom.xml
+++ b/http-framework/http-oauth2/pom.xml
@@ -51,16 +51,19 @@
     <dependency>
       <groupId>org.wrensecurity.http</groupId>
       <artifactId>chf-http-core</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.wrensecurity.commons</groupId>
       <artifactId>forgerock-util</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.wrensecurity.commons</groupId>
       <artifactId>json-web-token</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/http-framework/http-servlet/pom.xml
+++ b/http-framework/http-servlet/pom.xml
@@ -51,6 +51,7 @@
     <dependency>
       <groupId>org.wrensecurity.http</groupId>
       <artifactId>chf-http-core</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/i18n/i18n-slf4j/pom.xml
+++ b/i18n/i18n-slf4j/pom.xml
@@ -38,6 +38,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>i18n-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/json-crypto/json-crypto-cli/pom.xml
+++ b/json-crypto/json-crypto-cli/pom.xml
@@ -39,6 +39,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>security</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/json-crypto/json-crypto-core/pom.xml
+++ b/json-crypto/json-crypto-core/pom.xml
@@ -33,6 +33,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-util</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/json-ref/json-ref-core/pom.xml
+++ b/json-ref/json-ref-core/pom.xml
@@ -33,6 +33,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-util</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/json-schema/json-schema-core/pom.xml
+++ b/json-schema/json-schema-core/pom.xml
@@ -35,6 +35,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-util</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/json-web-token/pom.xml
+++ b/json-web-token/pom.xml
@@ -55,6 +55,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-util</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -89,17 +89,216 @@
 
     <properties>
         <pgpVerifyKeysVersion>1.9.0</pgpVerifyKeysVersion>
+
+        <activation.version>2.0.0</activation.version>
+        <assertj.version>3.19.0</assertj.version>
+        <jackson.version>2.15.2</jackson.version>
+        <jaxb-osgi.version>2.3.3</jaxb-osgi.version>
+        <jodaTime.version>2.10.9</jodaTime.version>
+        <jsr305.version>3.0.2</jsr305.version>
         <jxrPluginVersion>3.3.2</jxrPluginVersion>
+        <mockito.version>4.4.0</mockito.version>
+        <servlet-api.version>5.0.0</servlet-api.version>
+        <slf4j.version>2.0.17</slf4j.version>
+        <swagger.version>1.6.11</swagger.version>
+        <testng.version>7.8.0</testng.version>
+        <wrensec-guava.version>18.0.5</wrensec-guava.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.wrensecurity.commons</groupId>
-                <artifactId>commons-bom</artifactId>
-                <version>${project.version}</version>
-                <type>pom</type>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
                 <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+                <version>${jsr305.version}</version>
+            </dependency>
+
+            <!-- Upgrade version managed by swagger -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>32.1.2-android</version>
+
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>jsr305</artifactId>
+                    </exclusion>
+
+                    <exclusion>
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_annotations</artifactId>
+                    </exclusion>
+
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>listenablefuture</artifactId>
+                    </exclusion>
+
+                    <exclusion>
+                        <groupId>com.google.j2objc</groupId>
+                        <artifactId>j2objc-annotations</artifactId>
+                    </exclusion>
+
+                    <exclusion>
+                        <groupId>org.checkerframework</groupId>
+                        <artifactId>checker-qual</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-osgi</artifactId>
+                <version>${jaxb-osgi.version}</version>
+
+                <exclusions>
+                    <exclusion>
+                      <groupId>com.sun.activation</groupId>
+                      <artifactId>jakarta.activation</artifactId>
+                    </exclusion>
+              </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>io.swagger</groupId>
+                <artifactId>swagger-core</artifactId>
+                <version>${swagger.version}</version>
+
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-annotations</artifactId>
+                    </exclusion>
+
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
+
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.datatype</groupId>
+                        <artifactId>jackson-datatype-joda</artifactId>
+                    </exclusion>
+
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.dataformat</groupId>
+                        <artifactId>jackson-dataformat-yaml</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>io.swagger</groupId>
+                <artifactId>swagger-models</artifactId>
+                <version>${swagger.version}</version>
+            </dependency>
+
+            <dependency>
+              <groupId>jakarta.activation</groupId>
+              <artifactId>jakarta.activation-api</artifactId>
+              <version>${activation.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>${servlet-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>joda-time</groupId>
+                <artifactId>joda-time</artifactId>
+                <version>${jodaTime.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-nop</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-simple</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.testng</groupId>
+                <artifactId>testng</artifactId>
+                <version>${testng.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons.guava</groupId>
+                <artifactId>wrensec-guava-base</artifactId>
+                <version>${wrensec-guava.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons.guava</groupId>
+                <artifactId>wrensec-guava-cache</artifactId>
+                <version>${wrensec-guava.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons.guava</groupId>
+                <artifactId>wrensec-guava-collect</artifactId>
+                <version>${wrensec-guava.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons.guava</groupId>
+                <artifactId>wrensec-guava-hash</artifactId>
+                <version>${wrensec-guava.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons.guava</groupId>
+                <artifactId>wrensec-guava-net</artifactId>
+                <version>${wrensec-guava.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wrensecurity.commons.guava</groupId>
+                <artifactId>wrensec-guava-io</artifactId>
+                <version>${wrensec-guava.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/rest/api-descriptor/pom.xml
+++ b/rest/api-descriptor/pom.xml
@@ -60,16 +60,19 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-util</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-schema-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.http</groupId>
             <artifactId>chf-http-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -146,6 +149,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-test-utils</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/rest/json-resource-examples/pom.xml
+++ b/rest/json-resource-examples/pom.xml
@@ -36,11 +36,13 @@
     <dependency>
       <groupId>org.wrensecurity.http</groupId>
       <artifactId>chf-http-servlet</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.wrensecurity.commons</groupId>
       <artifactId>forgerock-util</artifactId>
+      <version>${project.version}</version>
     </dependency>
 
     <dependency>

--- a/rest/json-resource-http/pom.xml
+++ b/rest/json-resource-http/pom.xml
@@ -41,6 +41,7 @@
         <dependency>
             <groupId>org.wrensecurity.http</groupId>
             <artifactId>chf-http-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -92,12 +93,14 @@
         <dependency>
             <groupId>org.wrensecurity.http</groupId>
             <artifactId>chf-http-servlet</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.http</groupId>
             <artifactId>chf-client-apache-async</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -110,6 +113,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-test-utils</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/rest/json-resource/pom.xml
+++ b/rest/json-resource/pom.xml
@@ -33,21 +33,25 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-util</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>i18n-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.http</groupId>
             <artifactId>chf-http-core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>api-descriptor</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -59,6 +63,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-test-utils</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -33,6 +33,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-util</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -83,6 +84,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>i18n-core</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/self-service/forgerock-selfservice-core/pom.xml
+++ b/self-service/forgerock-selfservice-core/pom.xml
@@ -36,6 +36,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -51,6 +52,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-util</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -79,6 +81,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-test-utils</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/self-service/forgerock-selfservice-example/pom.xml
+++ b/self-service/forgerock-selfservice-example/pom.xml
@@ -65,21 +65,25 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.http</groupId>
             <artifactId>chf-http-servlet</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource-http</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-util</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/self-service/forgerock-selfservice-json/pom.xml
+++ b/self-service/forgerock-selfservice-json/pom.xml
@@ -47,11 +47,13 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-util</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/self-service/forgerock-selfservice-stages/pom.xml
+++ b/self-service/forgerock-selfservice-stages/pom.xml
@@ -41,11 +41,13 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource-http</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-resource</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -56,16 +58,19 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>json-web-token</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-util</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.wrensecurity.http</groupId>
             <artifactId>chf-client-apache-sync</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -94,6 +99,7 @@
         <dependency>
             <groupId>org.wrensecurity.commons</groupId>
             <artifactId>forgerock-test-utils</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This PR removes all external dependencies from the BOM module. These dependencies have been moved to the parent and this module no longer imports the BOM.

This change resolves an issue with the JavaDocs build for several modules.