### PR TITLE
Remove duplicated Maven plugins

### DIFF
--- a/doc-maven/xcite-maven-plugin/pom.xml
+++ b/doc-maven/xcite-maven-plugin/pom.xml
@@ -106,34 +106,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-javadoc</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/rest/json-resource-examples/pom.xml
+++ b/rest/json-resource-examples/pom.xml
@@ -105,11 +105,6 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
 
         <executions>


### PR DESCRIPTION
This PR removes the Maven plugins that have already been configured in `wrensec-parent` project. 